### PR TITLE
remove asyncio from installation as it has shipped with python since 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See this comparison table of the key differences between the requests and httpx 
 
 Before running the below examples, open up your terminal and install the required libraries:
 ```bash
-python -m pip install requests httpx aiohttp asyncio
+python -m pip install requests httpx aiohttp
 ```
 
 Below are syntax differences between the two. The following code uses the Requests library to send a GET request:


### PR DESCRIPTION
This no longer needs to be installed from PyPI: all of the minimum versions supported by the latest versions of these packages do not and have not supported python 3.3 for quite some time